### PR TITLE
working on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM registry.access.redhat.com/ubi8/nodejs-16 AS deps
 USER 0
 WORKDIR /app
 
+# Ensure that the user can access all application files
+RUN chmod -R g+rwX /app
+
 # Install dependencies based on the preferred package manager
 COPY package.json package-lock.json* ./
 RUN npm ci


### PR DESCRIPTION
From BC Gov stackoverflow: If you need to adapt the docker image to work on OpenShift, a common command that needs to be added is RUN chmod -R g+rwX /your/home/dir, to ensure that the user can access all application files.

https://stackoverflow.developer.gov.bc.ca/questions/103