### PR TITLE
Initial create of PINs (batch create)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,6 @@
         "default-case": "warn",
         "default-case-last": "error",
         "no-eval": "error",
-        "require-await": "warn",
         "spaced-comment": ["error", "always", {
             "line": {
                 "markers": ["/"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^1.4.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
-        "crypto-random-string": "^5.0.0",
+        "crypto-random-string": "3.3.1",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-rate-limit": "^6.7.1",
@@ -3321,28 +3321,22 @@
       }
     },
     "node_modules/crypto-random-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-5.0.0.tgz",
-      "integrity": "sha512-KWjTXWwxFd6a94m5CdRGW/t82Tr8DoBc9dNnPCAbFI1EBweN6v1tv8y4Y1m7ndkp/nkIBRxUxAzpaBnR2k3bcQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.1.tgz",
+      "integrity": "sha512-5j88ECEn6h17UePrLi6pn1JcLtAiANa3KExyr9y9Z5vo2mv56Gh3I4Aja/B9P9uyMwyxNHAHWv+nE72f30T5Dg==",
       "dependencies": {
-        "type-fest": "^2.12.2"
+        "type-fest": "^0.8.1"
       },
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/crypto-random-string/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/date-fns": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "bc-emli-pin-mgmt-be",
   "version": "1.0.0",
   "description": "BC Virtual Home Energy Rating PIN Management System Backend",
-  "main": "index.ts",
+  "exports": [
+    "./index.ts"
+  ],
   "scripts": {
     "build": "tsoa spec-and-routes && tsc",
     "dev": "concurrently \"nodemon\" \"nodemon -x tsoa spec-and-routes\"",
@@ -37,7 +39,7 @@
     "axios": "^1.4.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
-    "crypto-random-string": "^5.0.0",
+    "crypto-random-string": "3.3.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^6.7.1",

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -3,13 +3,13 @@ import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 @Entity()
 export class User {
     @PrimaryGeneratedColumn()
-    id!: number;
+    id: number;
 
     @Column()
-    firstName!: string;
+    firstName: string;
 
     @Column()
-    lastName!: string;
+    lastName: string;
 
     @Column()
     age!: number;

--- a/src/helpers/PINGenerator.ts
+++ b/src/helpers/PINGenerator.ts
@@ -1,0 +1,41 @@
+import { PIN, PINDictionary } from './types';
+
+export default class PINGenerator {
+    allowedChars: string = '0123456789abcdefghijklmnopqrstuvwxyz';
+    pinLength: number = 8;
+
+    /**
+     * Creates a single PIN, checking against the database to ensure it is unique
+     */
+    /* public create(): PIN {
+
+    } */
+
+    /**
+     * Creates a batch of PINS on first use, checking amongst themselves and not a database for uniqueness
+     * @param quantity is the number of PINS to create
+     */
+    public async initialCreate(quantity: number): Promise<PINDictionary> {
+        if (quantity <= 0) {
+            throw new RangeError(
+                'The number of PINS created must be greater than 0.',
+            );
+        }
+        const crs = await import('crypto-random-string');
+        const PINDictionary: PINDictionary = {};
+        for (let i: number = 0; i < quantity; i += 1) {
+            const newPIN: PIN = crs.default({
+                length: this.pinLength,
+                characters: this.allowedChars,
+            });
+            if (PINDictionary[newPIN]) {
+                // pin already exists
+                i -= 1;
+                continue; // try again
+            } else {
+                PINDictionary[newPIN] = 1; // add PIN to object / dictionary
+            }
+        }
+        return PINDictionary;
+    }
+}

--- a/src/helpers/PINGenerator.ts
+++ b/src/helpers/PINGenerator.ts
@@ -61,3 +61,4 @@ export default class PINGenerator {
         return PINDictionary;
     }
 }
+//

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,0 +1,4 @@
+export type PIN = string;
+export interface PINDictionary {
+    [key: PIN]: number;
+}

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -17,6 +17,7 @@ const level = () => {
 };
 
 const consoleFormat = winston.format.combine(
+    winston.format.label({ label: `pin-mgmt-be` }),
     winston.format.timestamp({ format: 'YYYY-MMM-DD HH:mm:ss' }),
     winston.format.colorize({ all: true }),
     winston.format.printf(
@@ -25,6 +26,7 @@ const consoleFormat = winston.format.combine(
 );
 
 const outputFormat = winston.format.combine(
+    winston.format.label({ label: `pin-mgmt-be` }),
     winston.format.timestamp({ format: 'YYYY-MMM-DD HH:mm:ss' }),
     winston.format.printf(
         (info) => `${info.timestamp} ${info.level}: ${info.message}`,

--- a/src/middleware/logger.ts
+++ b/src/middleware/logger.ts
@@ -17,7 +17,6 @@ const level = () => {
 };
 
 const consoleFormat = winston.format.combine(
-    winston.format.label({ label: `pin-mgmt-be` }),
     winston.format.timestamp({ format: 'YYYY-MMM-DD HH:mm:ss' }),
     winston.format.colorize({ all: true }),
     winston.format.printf(
@@ -26,10 +25,11 @@ const consoleFormat = winston.format.combine(
 );
 
 const outputFormat = winston.format.combine(
-    winston.format.label({ label: `pin-mgmt-be` }),
+    winston.format.label({ label: 'pin-mgmt-be' }),
     winston.format.timestamp({ format: 'YYYY-MMM-DD HH:mm:ss' }),
     winston.format.printf(
-        (info) => `${info.timestamp} ${info.level}: ${info.message}`,
+        (info) =>
+            `[${info.label}] ${info.timestamp} ${info.level}: ${info.message}`,
     ),
 );
 

--- a/src/tests/helpers/PINGenerator.spec.ts
+++ b/src/tests/helpers/PINGenerator.spec.ts
@@ -29,26 +29,26 @@ describe('PIN Generation Tests', () => {
     });
 
     test('Batch create 0 pins', async () => {
-        expect(gen.initialCreate(0)).rejects.toThrow(
+        await expect(gen.initialCreate(0)).rejects.toThrow(
             'The number of PINS created must be greater than 0.',
         );
     });
 
     test('Batch create force repeated PIN', async () => {
-        expect(gen.initialCreate(9, 3, 'AB')).rejects.toThrow(
+        await expect(gen.initialCreate(9, 3, 'AB')).rejects.toThrow(
             'Quantity of PINs requested too high: guaranteed repeats for the given pin length and character set.',
         );
     });
 
     test('Batch create too short PIN (length < 1)', async () => {
         // const gen = new PINGenerator();
-        expect(gen.initialCreate(1, 0)).rejects.toThrow(
+        await expect(gen.initialCreate(1, 0)).rejects.toThrow(
             'PIN must be of length 1 or greater',
         );
     });
 
     test('Batch create PIN with no characters in set', async () => {
-        expect(gen.initialCreate(1, 2, '')).rejects.toThrow(
+        await expect(gen.initialCreate(1, 2, '')).rejects.toThrow(
             'Quantity of PINs requested too high: guaranteed repeats for the given pin length and character set.',
         );
     });

--- a/src/tests/helpers/PINGenerator.spec.ts
+++ b/src/tests/helpers/PINGenerator.spec.ts
@@ -1,0 +1,55 @@
+import { PINDictionary } from '../../helpers/types.js';
+import PINGenerator from '../../helpers/PINGenerator';
+
+describe('PIN Generation Tests', () => {
+    let gen: PINGenerator;
+    beforeAll(() => {
+        gen = new PINGenerator();
+    });
+
+    test('Batch create 2 pins', async () => {
+        const output: PINDictionary = await gen.initialCreate(2);
+        expect(Object.keys(output).length).toBe(2); // there should be 2 pins
+        expect(Object.keys(output)[0]).not.toEqual(Object.keys(output)[1]); // pins should be unique
+    });
+
+    test('Batch create 100,000 pins (test correct number of outputs)', async () => {
+        const output: PINDictionary = await gen.initialCreate(100000);
+        expect(Object.keys(output).length).toBe(100000); // there should be 100,000 pins
+    });
+
+    test(`Batch create attempt repeated PIN`, async () => {
+        // Note: this won't guarantee a repeat but it's likely, only 4 possibilities
+        // Attempting to force a repeat by making the # of PINs greater than the number of possibilities
+        // will result in an error instead
+        const output: PINDictionary = await gen.initialCreate(4, 2, 'AB');
+        expect(Object.keys(output).length).toBe(4); // there should be 4 pins, despite possible repeats during the creation process
+        const outputSet = new Set(Object.keys(output));
+        expect(outputSet.size).toBe(4); // there should be 4 unique values in the set
+    });
+
+    test('Batch create 0 pins', async () => {
+        expect(gen.initialCreate(0)).rejects.toThrow(
+            'The number of PINS created must be greater than 0.',
+        );
+    });
+
+    test('Batch create force repeated PIN', async () => {
+        expect(gen.initialCreate(9, 3, 'AB')).rejects.toThrow(
+            'Quantity of PINs requested too high: guaranteed repeats for the given pin length and character set.',
+        );
+    });
+
+    test('Batch create too short PIN (length < 1)', async () => {
+        // const gen = new PINGenerator();
+        expect(gen.initialCreate(1, 0)).rejects.toThrow(
+            'PIN must be of length 1 or greater',
+        );
+    });
+
+    test('Batch create PIN with no characters in set', async () => {
+        expect(gen.initialCreate(1, 2, '')).rejects.toThrow(
+            'Quantity of PINs requested too high: guaranteed repeats for the given pin length and character set.',
+        );
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -87,7 +87,7 @@
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    "strictPropertyInitialization": false,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "types": ["jest"],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
@@ -107,5 +107,5 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "include": ["src"], 
-  "exclude": ["node_modules", "dist", "src/**/*.spec.ts", "src/build/**"],
+  "exclude": ["node_modules", "dist", "src/build/**"],
 }


### PR DESCRIPTION
- Created an initial batch creation algorithm for PINS. This checks uniqueness amongst the pins being created rather than the database, and outputs an object in the form { "pin" : pincount } (pincount should always be 1). This can be converted to a set if needed to remove the pincount, but it will add a small time cost.
- Added unit tests for the batch create function
- Made a few small changes to logging and configs (noted in the commits)

Linked to BVPS-158: https://deloittedigital.atlassian.net/jira/software/projects/BVPS/boards/535?assignee=6138f78024ba8b0070104e1c&selectedIssue=BVPS-158