### PR TITLE
Bvps 272 - GCNotify generic caller

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -30,3 +30,7 @@ JWT_SECRET=secret here
 BCGEOCODER_API_KEY_PID = 'apikey'
 GEOCODER_API_PARCELS_ENDPOINT='parcels/pids/'
 FE_APP_URL='front-end-app-url'
+
+GC_NOTIFY_API_KEY='apikey'
+GC_NOTIFY_URL='url'
+GC_NOTIFY_RETRY_LIMIT=3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1395,9 +1395,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -1537,12 +1537,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
-      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -6590,15 +6590,15 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
-      "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-util": "^29.6.1"
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6768,12 +6768,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "express-rate-limit": "^6.7.1",
         "jsonwebtoken": "^9.0.1",
         "morgan": "^1.10.0",
+        "notifications-node-client": "^7.0.3",
         "pg": "^8.11.1",
         "qs": "^6.11.2",
         "reflect-metadata": "^0.1.13",
@@ -7931,6 +7932,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/notifications-node-client": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-7.0.3.tgz",
+      "integrity": "sha512-uLuABa7ZK2XIP6aahHbtiCP4noyNIGclJ2idPh7cojnk2retajkpo0AZctSsDP18SUB0kUmHbBxOOJm2Gkb60g==",
+      "dependencies": {
+        "axios": "^0.25.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.17.3",
+        "npm": ">=6.14.13"
+      }
+    },
+    "node_modules/notifications-node-client/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "./index.ts"
   ],
   "scripts": {
-	"windows": "npm run build && node -r dotenv/config dist/index.js",
+    "windows": "npm run build && node -r dotenv/config dist/index.js",
     "build": "tsoa spec-and-routes && tsc",
     "dev": "concurrently \"nodemon\" \"nodemon -x tsoa spec-and-routes\"",
     "prepare": "husky install",
@@ -59,6 +59,7 @@
     "express-rate-limit": "^6.7.1",
     "jsonwebtoken": "^9.0.1",
     "morgan": "^1.10.0",
+    "notifications-node-client": "^7.0.3",
     "pg": "^8.11.1",
     "qs": "^6.11.2",
     "reflect-metadata": "^0.1.13",

--- a/src/helpers/GCNotifyCaller.ts
+++ b/src/helpers/GCNotifyCaller.ts
@@ -1,0 +1,113 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const NotifyClient = require('notifications-node-client').NotifyClient;
+import logger from '../middleware/logger';
+import { gcNotifyError } from './types';
+
+export default class GCNotifyCaller {
+    private notifyClient: any;
+    // The number of times you want to retry sending the text / email, read in from the environment variables
+    private retryLimit: number;
+
+    constructor() {
+        this.notifyClient = new NotifyClient(
+            process.env.GC_NOTIFY_URL as string,
+            process.env.GC_NOTIFY_API_KEY as string,
+        );
+        this.retryLimit = process.env.GC_NOTIFY_RETRY_LIMIT
+            ? Number.isInteger(parseInt(process.env.GC_NOTIFY_RETRY_LIMIT)) &&
+              parseInt(process.env.GC_NOTIFY_RETRY_LIMIT) > 0
+                ? parseInt(process.env.GC_NOTIFY_RETRY_LIMIT)
+                : 3
+            : 3;
+    }
+
+    /**
+     * Sends a GCNotify email to the specified email address.
+     * @param templateId is the templateId for the email
+     * @param email is the email address you wish to send the email to
+     * @param personalisation is an object with the parameters that can be customized in the template (ex: name, PIN)
+     * @returns true if GCNotify returns a 2xx response code, or an error otherwise
+     */
+    public async sendEmailNotification(
+        templateId: string,
+        email: string,
+        personalisation?: object,
+    ) {
+        // Attempt to send email x number of times. Throw error otherwise
+        for (let i = 0; i < this.retryLimit; i++) {
+            try {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const response = await this.notifyClient.sendEmail(
+                    templateId,
+                    email,
+                    { personalisation: personalisation },
+                );
+                return true;
+            } catch (err) {
+                let message =
+                    `Error(s) sending GCNotify email - ` +
+                    (err as gcNotifyError).response.status +
+                    ` ` +
+                    (err as gcNotifyError).response.statusText +
+                    `:`;
+                for (const error of (err as gcNotifyError).response.data
+                    .errors) {
+                    message =
+                        message + `\n` + error.error + `: ` + error.message;
+                }
+                if (err instanceof Error) {
+                    logger.error(message);
+                    if (i + 1 === this.retryLimit) {
+                        throw new Error(message);
+                    }
+                }
+                continue;
+            }
+        }
+    }
+
+    /**
+     * Sends a GCNotify text to the specified phone number.
+     * @param templateId is the templateId for the text message
+     * @param phone is the phone number you wish to send the text to, in string format
+     * @param personalisation is an object with the parameters that can be customized in the template (ex: name, PIN)
+     * @returns true if GCNotify returns a 2xx response code, or an error otherwise
+     */
+    public async sendPhoneNotification(
+        templateId: string,
+        phone: string,
+        personalisation?: object,
+    ) {
+        // Attempt to send text x number of times. Throw error otherwise
+        for (let i = 0; i < this.retryLimit; i++) {
+            try {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const response = await this.notifyClient.sendSms(
+                    templateId,
+                    phone,
+                    { personalisation: personalisation },
+                );
+                return true;
+            } catch (err) {
+                let message =
+                    `Error(s) sending GCNotify text - ` +
+                    (err as gcNotifyError).response.status +
+                    ` ` +
+                    (err as gcNotifyError).response.statusText +
+                    `:`;
+                for (const error of (err as gcNotifyError).response.data
+                    .errors) {
+                    message =
+                        message + `\n` + error.error + `: ` + error.message;
+                }
+                if (err instanceof Error) {
+                    logger.error(message);
+                    if (i + 1 === this.retryLimit) {
+                        throw new Error(message);
+                    }
+                }
+                continue;
+            }
+        }
+    }
+}

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -495,3 +495,26 @@ export interface serviceBCCreateRequestBody {
     allowedChars?: string;
     requesterUsername?: string;
 }
+
+/**
+ * A simplified version of the GCNotify error returned from the api
+ */
+export interface gcNotifyError {
+    response: gcNotifyErrorResponse;
+}
+
+interface gcNotifyErrorResponse {
+    data: gcNotifyErrorData;
+    status: number;
+    statusText: string;
+}
+
+interface gcNotifyErrorData {
+    errors: gcNotifyErrorInfo[];
+    status_code: number;
+}
+
+interface gcNotifyErrorInfo {
+    error: string;
+    message: string;
+}

--- a/src/tests/commonResponses.ts
+++ b/src/tests/commonResponses.ts
@@ -1,5 +1,6 @@
 import {
     createPinRequestBody,
+    gcNotifyError,
     serviceBCCreateRequestBody,
 } from '../helpers/types';
 
@@ -880,3 +881,36 @@ export const AuditLogMultiResponse = [
         titleStatus: undefined,
     },
 ];
+
+export const GCNotifyEmailSuccessResponse = {
+    status: 200,
+    data: {
+        id: '73307f99-4bba-4a24-a8dd-e270d07509a0',
+        reference: null,
+        uri: 'https://api.notification.canada.ca/v2/notifications/73307f99-4bba-4a24-a8dd-e270d07509a0',
+        template: {
+            id: 'cf430240-e5b6-4224-bd71-a02e098cc6e8', // this isn't one of our actual template ids, I've edited the response
+            version: 1,
+            uri: 'https://api.notification.canada.ca/services/bf3f9c9f-fcfe-45e3-aea9-bae75f93d741/templates/cf430240-e5b6-4224-bd71-a02e098cc6e8',
+        },
+        scheduled_for: null,
+        content: {
+            from_email: 'noreply_hers@notification.canada.ca',
+            body: 'This is a test.\r\n' + 'This should work',
+            subject: 'BC VHERS Create PIN',
+        },
+    },
+};
+
+export const GCNotifyEmailErrorResponse: gcNotifyError = {
+    response: {
+        status: 400,
+        statusText: 'Bad Request',
+        data: {
+            status_code: 400,
+            errors: [
+                { error: 'BadRequestError', message: 'Template not found' },
+            ],
+        },
+    },
+};

--- a/src/tests/helpers/GCNotifyCaller.spec.ts
+++ b/src/tests/helpers/GCNotifyCaller.spec.ts
@@ -1,0 +1,98 @@
+import GCNotifyCaller from '../../helpers/GCNotifyCaller';
+import {
+    GCNotifyEmailErrorResponse,
+    GCNotifyEmailSuccessResponse,
+} from '../commonResponses';
+
+jest.mock('notifications-node-client', () => {
+    return {
+        NotifyClient: jest.fn().mockImplementation(() => {
+            return {};
+        }),
+    };
+});
+
+describe('GCNotify Caller tests', () => {
+    beforeAll(() => {
+        process.env.GC_NOTIFY_RETRY_LIMIT = '2';
+    });
+    test('sendEmailNotification should work with the correct email address and parameters', async () => {
+        jest.spyOn(
+            GCNotifyCaller.prototype as any,
+            'sendEmail',
+        ).mockResolvedValueOnce(GCNotifyEmailSuccessResponse);
+        const caller = new GCNotifyCaller();
+        const response = await caller.sendEmailNotification(
+            'cf430240-e5b6-4224-bd71-a02e098cc6e8',
+            'example@example.com',
+            { line_1: 'This is a test.', line_2: 'This should work' },
+        );
+        expect(response).toBe(true);
+    });
+
+    test('sendEmailNotification should throw an error upon failure', async () => {
+        jest.spyOn(
+            GCNotifyCaller.prototype as any,
+            'sendEmail',
+        ).mockImplementationOnce(async () => {
+            throw GCNotifyEmailErrorResponse;
+        });
+        jest.spyOn(
+            GCNotifyCaller.prototype as any,
+            'sendEmail',
+        ).mockImplementationOnce(async () => {
+            throw GCNotifyEmailErrorResponse;
+        });
+        const caller = new GCNotifyCaller();
+        await expect(
+            caller.sendEmailNotification(
+                'cf430240-e5b6-4224-bd71-a02e098cc6e7',
+                'example@example.com',
+                {},
+            ),
+        ).rejects.toThrow(
+            'Error(s) sending GCNotify email - 400 Bad Request:\nBadRequestError: Template not found',
+        );
+    });
+
+    // TO BE UPDATED WITH AN ACTUAL RESPONSE ONCE WE HAVE SMS
+    test('sendPhoneNotification should work with the correct number and parameters', async () => {
+        jest.spyOn(
+            GCNotifyCaller.prototype as any,
+            'sendSms',
+        ).mockResolvedValueOnce(GCNotifyEmailSuccessResponse);
+        const caller = new GCNotifyCaller();
+        const response = await caller.sendPhoneNotification(
+            'cf430240-e5b6-4224-bd71-a02e098cc6e8',
+            '19021234567',
+            { line_1: 'This is a test.', line_2: 'This should work' },
+        );
+        expect(response).toBe(true);
+    });
+
+    // TO BE UPDATED WITH AN ACTUAL RESPONSE ONCE WE HAVE SMS
+    test('sendPhoneNotification should throw an error upon failure', async () => {
+        jest.spyOn(
+            GCNotifyCaller.prototype as any,
+            'sendSms',
+        ).mockImplementationOnce(async () => {
+            throw GCNotifyEmailErrorResponse;
+        });
+        jest.spyOn(
+            GCNotifyCaller.prototype as any,
+            'sendSms',
+        ).mockImplementationOnce(async () => {
+            throw GCNotifyEmailErrorResponse;
+        });
+        const caller = new GCNotifyCaller();
+        await expect(
+            caller.sendPhoneNotification(
+                'cf430240-e5b6-4224-bd71-a02e098cc6e7',
+                '19021234567',
+                {},
+            ),
+        ).rejects.toThrow(
+            'Error(s) sending GCNotify text - 400 Bad Request:\nBadRequestError: Template not found',
+        );
+    });
+});


### PR DESCRIPTION
This PR adds the GCNotifyCaller class, which contains 2 functions for sending data via GCNotify: sendEmailNotification and sendPhoneNotification. Note that a few environment variables have been added as follows:

`GC_NOTIFY_API_KEY='apikey'
GC_NOTIFY_URL='url'
GC_NOTIFY_RETRY_LIMIT=3`

The retry limit is the amount of times you wish to retry a request if it fails before giving up and throwing an error (defaults to 3 if no value is given)

- Added gcnotify text and email functionality
- Added tests