### PR TITLE
BVPS-289: Regenerate PIN API Key auth

### DIFF
--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -490,11 +490,14 @@ export function RegisterRoutes(app: Router) {
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         app.post('/pins/vhers-regenerate',
+            authenticateMiddleware([{"vhers_api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(PINController)),
             ...(fetchMiddlewares<RequestHandler>(PINController.prototype.recreatePin)),
 
             function PINController_recreatePin(request: any, response: any, next: any) {
             const args = {
+                    _invalidTokenErrorResponse: {"in":"res","name":"400","required":true,"ref":"InvalidTokenErrorResponse"},
+                    _unauthorizedErrorResponse: {"in":"res","name":"401","required":true,"ref":"UnauthorizedErrorResponse"},
                     rangeErrorResponse: {"in":"res","name":"422","required":true,"ref":"pinRangeErrorType"},
                     serverErrorResponse: {"in":"res","name":"500","required":true,"ref":"serverErrorType"},
                     aggregateErrorResponse: {"in":"res","name":"422","required":true,"ref":"aggregateValidationErrorType"},

--- a/src/build/swagger.json
+++ b/src/build/swagger.json
@@ -1166,6 +1166,26 @@
 							}
 						}
 					},
+					"400": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InvalidTokenErrorResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UnauthorizedErrorResponse"
+								}
+							}
+						}
+					},
 					"422": {
 						"description": "",
 						"content": {
@@ -1188,7 +1208,11 @@
 					}
 				},
 				"description": "Used to recreate a single, unique PIN, checking against the DB to do so.\nExpected error codes and messages:\n- `422`\n-- `PIN must be of length 1 or greater`\n-- `Too many PIN creation attempts: consider expanding your pin length or character set to allow more unique PINs.`\n-- `Error(s) occured in batchUpdatePin: []`\n- `500`\n -- `Internal Server Error`",
-				"security": [],
+				"security": [
+					{
+						"vhers_api_key": []
+					}
+				],
 				"parameters": [],
 				"requestBody": {
 					"required": true,

--- a/src/controllers/pinController.ts
+++ b/src/controllers/pinController.ts
@@ -861,8 +861,19 @@ export class PINController extends Controller {
      * @param The request body. See 'createRequestPinBody' in schemas for more details.
      * @returns An object containing the unique PIN
      */
+    @Security('vhers_api_key')
     @Post('vhers-regenerate')
     public async recreatePin(
+        @Res()
+        _invalidTokenErrorResponse: TsoaResponse<
+            400,
+            InvalidTokenErrorResponse
+        >,
+        @Res()
+        _unauthorizedErrorResponse: TsoaResponse<
+            401,
+            UnauthorizedErrorResponse
+        >,
         @Res() rangeErrorResponse: TsoaResponse<422, pinRangeErrorType>,
         @Res() serverErrorResponse: TsoaResponse<500, serverErrorType>,
         @Res()

--- a/src/routes/pins.ts
+++ b/src/routes/pins.ts
@@ -39,6 +39,8 @@ pinsRouter.post('/vhers-regenerate', async (req: Request, res: Response) => {
         () => {},
         () => {},
         () => {},
+        () => {},
+        () => {},
         req.body as createPinRequestBody,
     );
     return res.send(response);

--- a/src/tests/routes/pins.spec.ts
+++ b/src/tests/routes/pins.spec.ts
@@ -160,7 +160,7 @@ describe('Pin endpoints', () => {
         expect(res.body[0].pids).toBe('1234');
     });
 
-    test('verify PIN on API key not matching returns 400', async () => {
+    test('vhers-create on API key not matching returns 400', async () => {
         let lastCharChange = '';
         if (key[key.length - 1] === 'f') lastCharChange = '1';
         else lastCharChange = 'f';
@@ -685,18 +685,43 @@ describe('Pin endpoints', () => {
         const reqBody = validCreatePinBodyInc;
         const res = await request(app)
             .post('/pins/vhers-regenerate')
-            .send(reqBody);
+            .send(reqBody)
+            .set({ 'x-api-key': key });
         expect(res.statusCode).toBe(200);
         expect(res.body.length).toBe(1);
         expect(res.body[0].pin).toBe('ABCD1234');
         expect(res.body[0].pids).toBe('1234|5678');
     });
 
+    test('vhers-regenerate on API key not matching returns 400', async () => {
+        let lastCharChange = '';
+        if (key[key.length - 1] === 'f') lastCharChange = '1';
+        else lastCharChange = 'f';
+        const extraKey = key.substring(0, key.length - 1) + lastCharChange;
+        const reqBody = validCreatePinBodySinglePid;
+        const res = await request(app)
+            .post('/pins/vhers-regenerate')
+            .send(reqBody)
+            .set({ 'x-api-key': extraKey });
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toBe('Invalid Token');
+    });
+
+    test('vhers-regenerate on no API key provided returns 401', async () => {
+        const reqBody = validCreatePinBodySinglePid;
+        const res = await request(app)
+            .post('/pins/vhers-regenerate')
+            .send(reqBody);
+        expect(res.statusCode).toBe(401);
+        expect(res.body.message).toBe('Access Denied');
+    });
+
     test('vhers-regenerate on request body validation fail returns 422', async () => {
         const reqBody = invalidCreatePinBodyWrongPhone;
         const res = await request(app)
             .post('/pins/vhers-regenerate')
-            .send(reqBody);
+            .send(reqBody)
+            .set({ 'x-api-key': key });
         expect(res.statusCode).toBe(422);
         expect(res.body.message).toBe(
             'Validation Error(s) occured in createPin request body:',
@@ -716,7 +741,8 @@ describe('Pin endpoints', () => {
         reqBody.lastName_2 = 'Appleseed';
         const res = await request(app)
             .post('/pins/vhers-regenerate')
-            .send(reqBody);
+            .send(reqBody)
+            .set({ 'x-api-key': key });
         expect(res.statusCode).toBe(422);
         expect(res.body.message).toBe(
             'Pids 1234|5678 does not match the address and name / incorporation number given:' +
@@ -751,7 +777,8 @@ describe('Pin endpoints', () => {
         const reqBody = invalidCreatePinBodyPinLength;
         const res = await request(app)
             .post('/pins/vhers-regenerate')
-            .send(reqBody);
+            .send(reqBody)
+            .set({ 'x-api-key': key });
         expect(res.statusCode).toBe(422);
         expect(res.body.message).toBe('PIN must be of length 1 or greater');
     });
@@ -761,7 +788,8 @@ describe('Pin endpoints', () => {
         const reqBody = validCreatePinBodySinglePid;
         const res = await request(app)
             .post('/pins/vhers-regenerate')
-            .send(reqBody);
+            .send(reqBody)
+            .set({ 'x-api-key': key });
         expect(res.statusCode).toBe(500);
         expect(res.body.message).toBe(
             `Cannot read properties of undefined (reading 'metadata')`,


### PR DESCRIPTION
This PR adds api key authentication to /pins/vhers-regenerate.

- Added /pins/vhers-regenerate api key endpoint changes 
- Fixed tests