### PR TITLE
BVPS-333: Adding "-" to the PIN in GcNotify

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -42,7 +42,5 @@ GC_NOTIFY_EXPIRE_EMAIL_TEMPLATE_ID='expire-email-template-id'
 GC_NOTIFY_EXPIRE_PHONE_TEMPLATE_ID='expire-phone-template-id'
 GC_NOTIFY_VHERS_ADMIN_EMAIL='hers_admin@gov.bc.ca'
 GC_NOTIFY_ACCESS_REQUEST_EMAIL_TEMPLATE_ID='access-request-email-template-id'
-GC_NOTIFY_ACCESS_REQUEST_EMAIL_TEMPLATE_ID='access-request-email-template-id'
-GC_NOTIFY_VHERS_ADMIN_EMAIL='vhers-admin-email'
 
 VHERS_API_KEY=''

--- a/src/entity/PinAuditLog.ts
+++ b/src/entity/PinAuditLog.ts
@@ -36,8 +36,8 @@ export class PinAuditLog {
     })
     fromLandTitleDistrict: string | null;
 
-    @Column('enum', { name: 'title_status', enum: ['R', 'C'] })
-    titleStatus: 'R' | 'C';
+    @Column('character varying', { name: 'title_status', length: 1 })
+    titleStatus: string;
 
     @Column('timestamp with time zone', { name: 'expired_at', nullable: true })
     expiredAt: Date | null;

--- a/src/helpers/GCNotifyCaller.ts
+++ b/src/helpers/GCNotifyCaller.ts
@@ -62,6 +62,15 @@ export default class GCNotifyCaller {
         // Attempt to send email x number of times. Throw error otherwise
         for (let i = 0; i < this.retryLimit; i++) {
             try {
+                if (personalisation && Object.hasOwn(personalisation, 'pin')) {
+                    (personalisation as any).pin =
+                        ((personalisation as any).pin as string).substring(
+                            0,
+                            4,
+                        ) +
+                        '-' +
+                        ((personalisation as any).pin as string).substring(4);
+                }
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const response = await this.sendEmail(
                     notifyClient,
@@ -110,6 +119,15 @@ export default class GCNotifyCaller {
         // Attempt to send text x number of times. Throw error otherwise
         for (let i = 0; i < this.retryLimit; i++) {
             try {
+                if (personalisation && Object.hasOwn(personalisation, 'pin')) {
+                    (personalisation as any).pin =
+                        ((personalisation as any).pin as string).substring(
+                            0,
+                            4,
+                        ) +
+                        '-' +
+                        ((personalisation as any).pin as string).substring(4);
+                }
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const response = await this.sendSms(
                     notifyClient,

--- a/src/migration/1698348320098-migration.ts
+++ b/src/migration/1698348320098-migration.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migration1698348320098 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const schemaName = process.env.NODE_ENV === 'test' ? 'test' : 'public';
+        await queryRunner.query(
+            `ALTER TABLE IF EXISTS ${schemaName}.pin_audit_log ALTER COLUMN title_status TYPE VARCHAR(1)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const schemaName = process.env.NODE_ENV === 'test' ? 'test' : 'public';
+        await queryRunner.query(
+            `ALTER TABLE IF EXISTS ${schemaName}.pin_audit_log ALTER COLUMN title_status TYPE title_status_type`,
+        );
+    }
+}

--- a/src/tests/helpers/GCNotifyCaller.spec.ts
+++ b/src/tests/helpers/GCNotifyCaller.spec.ts
@@ -25,7 +25,11 @@ describe('GCNotify Caller tests', () => {
         const response = await caller.sendEmailNotification(
             'cf430240-e5b6-4224-bd71-a02e098cc6e8',
             'example@example.com',
-            { line_1: 'This is a test.', line_2: 'This should work' },
+            {
+                line_1: 'This is a test.',
+                line_2: 'This should work',
+                pin: 'abcdefg',
+            },
         );
         expect(response).toBe(true);
     });


### PR DESCRIPTION
Fixed the GCNotify caller to include a hyphen in pins. Also fixed a trigger issue that was causing logs not to go through with a db migration, so run `npm run db:migrate` to fix any issues.