### PR TITLE
BVPS-335: Add address score endpoint (and thresholds) for demonstration purposes

### DIFF
--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -181,16 +181,6 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "updatedPIN": {
-        "dataType": "refObject",
-        "properties": {
-            "pin": {"dataType":"string"},
-            "pids": {"dataType":"string","required":true},
-            "livePinId": {"dataType":"string","required":true},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "InvalidTokenErrorResponse": {
         "dataType": "refObject",
         "properties": {
@@ -253,6 +243,16 @@ const models: TsoaRoute.Models = {
             "postalCode": {"dataType":"string"},
             "requesterUsername": {"dataType":"string"},
             "propertyAddress": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "updatedPIN": {
+        "dataType": "refObject",
+        "properties": {
+            "pin": {"dataType":"string"},
+            "pids": {"dataType":"string","required":true},
+            "livePinId": {"dataType":"string","required":true},
         },
         "additionalProperties": false,
     },
@@ -547,6 +547,66 @@ export function RegisterRoutes(app: Router) {
 
 
               const promise = controller.getAuditLogs.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/pins/score',
+            authenticateMiddleware([{"vhers_api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(PINController)),
+            ...(fetchMiddlewares<RequestHandler>(PINController.prototype.addressScore)),
+
+            function PINController_addressScore(request: any, response: any, next: any) {
+            const args = {
+                    _invalidTokenErrorResponse: {"in":"res","name":"400","required":true,"ref":"InvalidTokenErrorResponse"},
+                    _unauthorizedErrorResponse: {"in":"res","name":"401","required":true,"ref":"UnauthorizedErrorResponse"},
+                    rangeErrorResponse: {"in":"res","name":"422","required":true,"ref":"pinRangeErrorType"},
+                    serverErrorResponse: {"in":"res","name":"500","required":true,"ref":"serverErrorType"},
+                    aggregateErrorResponse: {"in":"res","name":"422","required":true,"ref":"aggregateValidationErrorType"},
+                    notFoundErrorResponse: {"in":"res","name":"422","required":true,"ref":"EntityNotFoundErrorType"},
+                    requestBody: {"in":"body","name":"requestBody","required":true,"ref":"createPinRequestBody"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new PINController();
+
+
+              const promise = controller.addressScore.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.get('/pins/thresholds',
+            authenticateMiddleware([{"vhers_api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(PINController)),
+            ...(fetchMiddlewares<RequestHandler>(PINController.prototype.weightsThresholds)),
+
+            function PINController_weightsThresholds(request: any, response: any, next: any) {
+            const args = {
+                    _invalidTokenErrorResponse: {"in":"res","name":"400","required":true,"ref":"InvalidTokenErrorResponse"},
+                    _unauthorizedErrorResponse: {"in":"res","name":"401","required":true,"ref":"UnauthorizedErrorResponse"},
+                    serverErrorResponse: {"in":"res","name":"500","required":true,"ref":"serverErrorType"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new PINController();
+
+
+              const promise = controller.weightsThresholds.apply(controller, validatedArgs as any);
               promiseHandler(controller, promise, response, undefined, next);
             } catch (err) {
                 return next(err);

--- a/src/build/swagger.json
+++ b/src/build/swagger.json
@@ -431,31 +431,6 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"updatedPIN": {
-				"description": "A PIN updated for a homeowner and its corresponding parcel & database identifiers. Defaults to 8 character length and\nall numbers + lowercase letters as the character set.",
-				"properties": {
-					"pin": {
-						"type": "string"
-					},
-					"pids": {
-						"type": "string"
-					},
-					"livePinId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"pids",
-					"livePinId"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"pin": "abcdefgh",
-					"pids": "1234",
-					"livePinId": "cf430240-e5b6-4224-bd71-a02e098cc6e8"
-				}
-			},
 			"InvalidTokenErrorResponse": {
 				"description": "The response given when the api key provided in a request is invalid",
 				"properties": {
@@ -630,6 +605,31 @@
 					"country": "Canada",
 					"postalCode": "V1V1V1",
 					"propertyAddress": "8765 Willow Way, Chilliwack, BC"
+				}
+			},
+			"updatedPIN": {
+				"description": "A PIN updated for a homeowner and its corresponding parcel & database identifiers. Defaults to 8 character length and\nall numbers + lowercase letters as the character set.",
+				"properties": {
+					"pin": {
+						"type": "string"
+					},
+					"pids": {
+						"type": "string"
+					},
+					"livePinId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"pids",
+					"livePinId"
+				],
+				"type": "object",
+				"additionalProperties": false,
+				"example": {
+					"pin": "abcdefgh",
+					"pids": "1234",
+					"livePinId": "cf430240-e5b6-4224-bd71-a02e098cc6e8"
 				}
 			},
 			"serviceBCCreateRequestBody": {
@@ -1309,6 +1309,130 @@
 						}
 					}
 				]
+			}
+		},
+		"/pins/score": {
+			"post": {
+				"operationId": "AddressScore",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {}
+							}
+						}
+					},
+					"400": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InvalidTokenErrorResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UnauthorizedErrorResponse"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/EntityNotFoundErrorType"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/serverErrorType"
+								}
+							}
+						}
+					}
+				},
+				"description": "Shows off the address match score function without actually updating pins.",
+				"security": [
+					{
+						"vhers_api_key": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/createPinRequestBody"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/pins/thresholds": {
+			"get": {
+				"operationId": "WeightsThresholds",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {}
+							}
+						}
+					},
+					"400": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InvalidTokenErrorResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UnauthorizedErrorResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/serverErrorType"
+								}
+							}
+						}
+					}
+				},
+				"description": "Displays the current weights, thresholds and fuzzy match coefficients used for scoring addresses",
+				"security": [
+					{
+						"vhers_api_key": []
+					}
+				],
+				"parameters": []
 			}
 		},
 		"/pins/vhers-create": {

--- a/src/controllers/pinController.ts
+++ b/src/controllers/pinController.ts
@@ -816,55 +816,225 @@ export class PINController extends Controller {
         return result;
     }
 
-    public async addressScore(@Body() requestBody: createPinRequestBody) {
-        // Validate that the input request is correct
-        const faults = this.pinRequestBodyValidate(requestBody);
-        if (faults.length > 0) {
-            throw new AggregateError(
-                faults,
-                'Validation Error(s) occured in createPin request body:',
-            );
-        }
-
-        // Grab input pid(s)
-        const pids: string[] = pidStringSplitAndSort(requestBody.pids);
-        let where;
-        if (pids.length === 1) {
-            where = { pids: Like(`%` + pids[0] + `%`) };
-        } else {
-            where = [];
-            for (let i = 0; i < pids.length; i++) {
-                where.push({ pids: Like(`%` + pids[i] + `%`) });
+    /**
+     * Shows off the address match score function without actually updating pins.
+     */
+    @Security('vhers_api_key')
+    @Post('score')
+    public async addressScore(
+        @Res()
+        _invalidTokenErrorResponse: TsoaResponse<
+            400,
+            InvalidTokenErrorResponse
+        >,
+        @Res()
+        _unauthorizedErrorResponse: TsoaResponse<
+            401,
+            UnauthorizedErrorResponse
+        >,
+        @Res() rangeErrorResponse: TsoaResponse<422, pinRangeErrorType>,
+        @Res() serverErrorResponse: TsoaResponse<500, serverErrorType>,
+        @Res()
+        aggregateErrorResponse: TsoaResponse<422, aggregateValidationErrorType>,
+        @Res()
+        notFoundErrorResponse: TsoaResponse<422, EntityNotFoundErrorType>,
+        @Body() requestBody: createPinRequestBody,
+    ) {
+        try {
+            // Validate that the input request is correct
+            const faults = this.pinRequestBodyValidate(requestBody);
+            if (faults.length > 0) {
+                throw new AggregateError(
+                    faults,
+                    'Validation Error(s) occured in createPin request body:',
+                );
             }
-        }
 
-        // Find Active PIN entry (or entries if more than one pid to insert or update
-        let pinResults = await findPin(undefined, where);
-        pinResults = sortActivePinResults(pinResults);
+            // Grab input pid(s)
+            const pids: string[] = pidStringSplitAndSort(requestBody.pids);
+            let where;
+            if (pids.length === 1) {
+                where = { pids: Like(`%` + pids[0] + `%`) };
+            } else {
+                where = [];
+                for (let i = 0; i < pids.length; i++) {
+                    where.push({ pids: Like(`%` + pids[i] + `%`) });
+                }
+            }
+            const select = {
+                livePinId: true,
+                pids: true,
+                titleNumber: true,
+                landTitleDistrict: true,
+                givenName: true,
+                lastName_1: true,
+                lastName_2: true,
+                incorporationNumber: true,
+                addressLine_1: true,
+                addressLine_2: true,
+                city: true,
+                provinceAbbreviation: true,
+                provinceLong: true,
+                country: true,
+                postalCode: true,
+            };
+            // Find Active PIN entry (or entries if more than one pid to insert or update
+            let pinResults = await findPin(select, where);
+            pinResults = sortActivePinResults(pinResults);
 
-        // const updateResults = [];
-        // const borderlineResults = [];
-        // const thresholds = (await this.dynamicImportCaller()).thresholds;
-        const pinResultKeys = Object.keys(pinResults);
-        const contactMessages = new Set();
+            const updateResults = [];
+            // const borderlineResults = [];
+            // const thresholds = (await this.dynamicImportCaller()).thresholds;
+            const pinResultKeys = Object.keys(pinResults);
+            const contactMessages = new Set();
 
-        if (pinResultKeys.length > 0) {
-            for (const key of pinResultKeys) {
-                const titleOwners = pinResults[key].length;
-                for (let i = 0; i < titleOwners; i++) {
-                    const matchScore = await this.pinResultValidate(
-                        requestBody,
-                        pinResults[key][i],
-                        titleOwners,
-                    );
-                    if (!('weightedAverage' in matchScore)) {
-                        // it's a string array
-                        for (const message of matchScore) {
-                            contactMessages.add(message);
+            if (pinResultKeys.length > 0) {
+                for (const key of pinResultKeys) {
+                    const titleOwners = pinResults[key].length;
+                    for (let i = 0; i < titleOwners; i++) {
+                        const matchScore = await this.pinResultValidate(
+                            requestBody,
+                            pinResults[key][i],
+                            titleOwners,
+                        );
+                        if (!('weightedAverage' in matchScore)) {
+                            // it's a string array
+                            for (const message of matchScore) {
+                                contactMessages.add(message);
+                            }
+                            continue; // bad match, skip
+                        } else {
+                            updateResults.push({
+                                ActivePin: pinResults[key][i],
+                                matchScore,
+                            });
                         }
-                        continue; // bad match, skip
                     }
                 }
+                updateResults.sort(
+                    (a, b) =>
+                        b.matchScore.weightedAverage -
+                        a.matchScore.weightedAverage,
+                );
+            }
+
+            if (updateResults.length > 0) {
+                return updateResults[0];
+            } else {
+                let errMessage;
+                if (contactMessages.size > 0) {
+                    errMessage = '';
+                    for (const message of contactMessages) {
+                        errMessage += message + `\n`;
+                    }
+                    errMessage = errMessage.substring(0, errMessage.length - 1);
+                } else {
+                    errMessage = `Pids ${requestBody.pids} does not match the address and name / incorporation number given:\n`;
+                    let newLineFlag = false;
+                    // Line 1
+                    if (requestBody.givenName)
+                        errMessage += `${requestBody.givenName} `;
+                    errMessage += `${requestBody.lastName_1} `;
+                    if (requestBody.lastName_2)
+                        errMessage += `${requestBody.lastName_2} `;
+                    if (requestBody.incorporationNumber)
+                        errMessage += `Inc. # ${requestBody.incorporationNumber}`;
+                    // Line 2
+                    if (requestBody.addressLine_1)
+                        errMessage += `\n${requestBody.addressLine_1}`;
+                    // Line 3
+                    if (requestBody.addressLine_2)
+                        errMessage += `\n${requestBody.addressLine_2}`;
+                    // Line 4
+                    if (requestBody.city) {
+                        newLineFlag = true;
+                        errMessage += `\n${requestBody.city}`;
+                    }
+                    if (requestBody.provinceAbbreviation) {
+                        if (!newLineFlag) {
+                            newLineFlag = true;
+                            errMessage += `\n${requestBody.provinceAbbreviation}`;
+                        } else {
+                            errMessage += `, ${requestBody.provinceAbbreviation}`;
+                        }
+                    }
+                    if (requestBody.country) {
+                        if (!newLineFlag) {
+                            newLineFlag = true;
+                            errMessage += `\n${requestBody.country}`;
+                        } else {
+                            errMessage += `, ${requestBody.country}`;
+                        }
+                    }
+                    if (requestBody.postalCode) {
+                        if (!newLineFlag)
+                            errMessage += `\n${requestBody.postalCode}`;
+                        else errMessage += ` ${requestBody.postalCode}`;
+                    }
+                }
+                throw new NotFoundError(errMessage);
+            }
+        } catch (err) {
+            if (
+                err instanceof NotFoundError ||
+                err instanceof BorderlineResultError
+            ) {
+                logger.warn(
+                    `Encountered not found error in createPin: ${err.message}`,
+                );
+                return notFoundErrorResponse(422, {
+                    message: err.message,
+                } as EntityNotFoundErrorType);
+            }
+            if (err instanceof AggregateError) {
+                logger.warn(`${err.message} ${err.errors}`);
+                return aggregateErrorResponse(422, {
+                    message: err.message,
+                    faults: err.errors,
+                });
+            }
+            if (err instanceof RangeError) {
+                logger.warn(
+                    `Encountered Range Error in createPin: ${err.message}`,
+                );
+                return rangeErrorResponse(422, {
+                    message: err.message,
+                } as pinRangeErrorType);
+            } else if (err instanceof Error) {
+                logger.warn(
+                    `Encountered unknown Internal Server Error in createPin: ${err.message}`,
+                );
+                return serverErrorResponse(500, { message: err.message });
+            }
+        }
+    }
+
+    /**
+     * Displays the current weights, thresholds and fuzzy match coefficients used for scoring addresses
+     */
+    @Security('vhers_api_key')
+    @Get('thresholds')
+    public async weightsThresholds(
+        @Res()
+        _invalidTokenErrorResponse: TsoaResponse<
+            400,
+            InvalidTokenErrorResponse
+        >,
+        @Res()
+        _unauthorizedErrorResponse: TsoaResponse<
+            401,
+            UnauthorizedErrorResponse
+        >,
+        @Res() serverErrorResponse: TsoaResponse<500, serverErrorType>,
+    ) {
+        try {
+            const values = await this.dynamicImportCaller();
+            return values;
+        } catch (err) {
+            if (err instanceof Error) {
+                const message = `Error in weightsThresholds: failed to grab thresholds`;
+                logger.warn(message);
+                return serverErrorResponse(500, { message });
             }
         }
     }

--- a/src/routes/pins.ts
+++ b/src/routes/pins.ts
@@ -95,4 +95,26 @@ pinsRouter.post('/verify', async (req: Request, res: Response) => {
     return res.send(response);
 });
 
+pinsRouter.post('/score', async (req: Request, res: Response) => {
+    const response = await controller.addressScore(
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        req.body,
+    );
+    return res.send(response);
+});
+
+pinsRouter.get('/thresholds', async (req: Request, res: Response) => {
+    const response = await controller.weightsThresholds(
+        () => {},
+        () => {},
+        () => {},
+    );
+    return res.send(response);
+});
+
 export default pinsRouter;


### PR DESCRIPTION
This PR adds 2 endpoints, /pins/score and /pins/thresholds. These are for the purpose of showing off the address match functionality, and are not meant to be permanent. Both require api key authentication. 

The score endpoint accepts the same parameters as the /pins/vhers-create and /pins/vhers-regenerate endpoints, but does not update the pin. Instead it shows the best matching pin and its score. 
The thresholds endpoint simply displays the current weights, thresholds, and fuzzy match coefficients.