### PR TITLE
BVPS-337: Request access table check if user already exists with NotGranted status

### DIFF
--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -20,6 +20,48 @@ import type { RequestHandler, Router } from 'express';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 
 const models: TsoaRoute.Models = {
+    "InvalidTokenErrorResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "message": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UnauthorizedErrorResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "message": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "verifyPinErrorType": {
+        "dataType": "refObject",
+        "properties": {
+            "errorType": {"dataType":"string"},
+            "errorMessage": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "verifyPinResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "verified": {"dataType":"boolean","required":true},
+            "reason": {"ref":"verifyPinErrorType"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "DuplicateRequestErrorType": {
+        "dataType": "refObject",
+        "properties": {
+            "message": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "GenericTypeORMErrorType": {
         "dataType": "refObject",
         "properties": {
@@ -190,22 +232,6 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "InvalidTokenErrorResponse": {
-        "dataType": "refObject",
-        "properties": {
-            "message": {"dataType":"string","required":true},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "UnauthorizedErrorResponse": {
-        "dataType": "refObject",
-        "properties": {
-            "message": {"dataType":"string","required":true},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "pinRangeErrorType": {
         "dataType": "refObject",
         "properties": {
@@ -333,24 +359,6 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "verifyPinErrorType": {
-        "dataType": "refObject",
-        "properties": {
-            "errorType": {"dataType":"string"},
-            "errorMessage": {"dataType":"string","required":true},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "verifyPinResponse": {
-        "dataType": "refObject",
-        "properties": {
-            "verified": {"dataType":"boolean","required":true},
-            "reason": {"ref":"verifyPinErrorType"},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "verifyPinRequestBody": {
         "dataType": "refObject",
         "properties": {
@@ -426,6 +434,10 @@ export function RegisterRoutes(app: Router) {
 
             function AccessRequestController_createAccessRequest(request: any, response: any, next: any) {
             const args = {
+                    _invalidTokenErrorResponse: {"in":"res","name":"400","required":true,"ref":"InvalidTokenErrorResponse"},
+                    _unauthorizedErrorResponse: {"in":"res","name":"401","required":true,"ref":"UnauthorizedErrorResponse"},
+                    _notFoundErrorResponse: {"in":"res","name":"404","required":true,"ref":"verifyPinResponse"},
+                    duplicateErrorResponse: {"in":"res","name":"409","required":true,"ref":"DuplicateRequestErrorType"},
                     typeORMErrorResponse: {"in":"res","name":"422","required":true,"ref":"GenericTypeORMErrorType"},
                     requiredFieldErrorResponse: {"in":"res","name":"422","required":true,"ref":"requiredFieldErrorType"},
                     serverErrorResponse: {"in":"res","name":"500","required":true,"ref":"serverErrorType"},
@@ -486,6 +498,8 @@ export function RegisterRoutes(app: Router) {
 
             function AccessRequestController_updateAccessRequest(request: any, response: any, next: any) {
             const args = {
+                    _invalidTokenErrorResponse: {"in":"res","name":"400","required":true,"ref":"InvalidTokenErrorResponse"},
+                    _unauthorizedErrorResponse: {"in":"res","name":"401","required":true,"ref":"UnauthorizedErrorResponse"},
                     typeORMErrorResponse: {"in":"res","name":"422","required":true,"ref":"GenericTypeORMErrorType"},
                     requiredFieldErrorResponse: {"in":"res","name":"422","required":true,"ref":"requiredFieldErrorType"},
                     serverErrorResponse: {"in":"res","name":"500","required":true,"ref":"serverErrorType"},

--- a/src/build/swagger.json
+++ b/src/build/swagger.json
@@ -6,6 +6,92 @@
 		"requestBodies": {},
 		"responses": {},
 		"schemas": {
+			"InvalidTokenErrorResponse": {
+				"description": "The response given when the api key provided in a request is invalid",
+				"properties": {
+					"message": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false,
+				"example": {
+					"message": "Invalid Token"
+				}
+			},
+			"UnauthorizedErrorResponse": {
+				"description": "The response given when an api key is not provided in a request that requires it",
+				"properties": {
+					"message": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false,
+				"example": {
+					"message": "Access Denied"
+				}
+			},
+			"verifyPinErrorType": {
+				"properties": {
+					"errorType": {
+						"type": "string"
+					},
+					"errorMessage": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"errorMessage"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"verifyPinResponse": {
+				"description": "The response given from a verify pin request.\nIf verified is false, the reason that the PIN was not verified is given.",
+				"properties": {
+					"verified": {
+						"type": "boolean"
+					},
+					"reason": {
+						"$ref": "#/components/schemas/verifyPinErrorType"
+					}
+				},
+				"required": [
+					"verified"
+				],
+				"type": "object",
+				"additionalProperties": false,
+				"example": {
+					"verified": false,
+					"reason": {
+						"errorType": "NotFoundError",
+						"errorMessage": "PIN was unable to be verified"
+					}
+				}
+			},
+			"DuplicateRequestErrorType": {
+				"description": "The error given when there already exists an access request for a user that has not yet been approved or rejected.",
+				"properties": {
+					"message": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false,
+				"example": {
+					"message": "There already exists an access request for this user. Please contact your administrator."
+				}
+			},
 			"GenericTypeORMErrorType": {
 				"description": "A generic error given by TypeORM. Often related to invalid syntax for input parameters",
 				"properties": {
@@ -453,38 +539,6 @@
 				"type": "object",
 				"additionalProperties": false
 			},
-			"InvalidTokenErrorResponse": {
-				"description": "The response given when the api key provided in a request is invalid",
-				"properties": {
-					"message": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"message"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"message": "Invalid Token"
-				}
-			},
-			"UnauthorizedErrorResponse": {
-				"description": "The response given when an api key is not provided in a request that requires it",
-				"properties": {
-					"message": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"message"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"message": "Access Denied"
-				}
-			},
 			"pinRangeErrorType": {
 				"description": "Generic range error that may occur when you give a value out of bounds to a pin function",
 				"properties": {
@@ -863,44 +917,6 @@
 					"email": "test@gmail.com"
 				}
 			},
-			"verifyPinErrorType": {
-				"properties": {
-					"errorType": {
-						"type": "string"
-					},
-					"errorMessage": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"errorMessage"
-				],
-				"type": "object",
-				"additionalProperties": false
-			},
-			"verifyPinResponse": {
-				"description": "The response given from a verify pin request.\nIf verified is false, the reason that the PIN was not verified is given.",
-				"properties": {
-					"verified": {
-						"type": "boolean"
-					},
-					"reason": {
-						"$ref": "#/components/schemas/verifyPinErrorType"
-					}
-				},
-				"required": [
-					"verified"
-				],
-				"type": "object",
-				"additionalProperties": false,
-				"example": {
-					"verified": false,
-					"reason": {
-						"errorType": "NotFoundError",
-						"errorMessage": "PIN was unable to be verified"
-					}
-				}
-			},
 			"verifyPinRequestBody": {
 				"description": "The information needed to verify a pin from the VHERS side.\nNote that the pids are seperated by a vertical bar (|)",
 				"properties": {
@@ -1090,6 +1106,46 @@
 					"201": {
 						"description": "Created"
 					},
+					"400": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InvalidTokenErrorResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UnauthorizedErrorResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/verifyPinResponse"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DuplicateRequestErrorType"
+								}
+							}
+						}
+					},
 					"422": {
 						"description": "",
 						"content": {
@@ -1218,6 +1274,26 @@
 				"responses": {
 					"204": {
 						"description": "No content"
+					},
+					"400": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InvalidTokenErrorResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UnauthorizedErrorResponse"
+								}
+							}
+						}
 					},
 					"403": {
 						"description": "",

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -673,3 +673,13 @@ export interface UnauthorizedErrorResponse {
 export interface InvalidTokenErrorResponse {
     message: string;
 }
+
+/**
+* The error given when there already exists an access request for a user that has not yet been approved or rejected.
+* @example {
+	"message": "There already exists an access request for this user. Please contact your administrator."
+  }
+*/
+export interface DuplicateRequestErrorType {
+    message: string;
+}

--- a/src/routes/accessRequest.ts
+++ b/src/routes/accessRequest.ts
@@ -14,6 +14,10 @@ accessRequestRouter.post('', async (req: Request, res: Response) => {
         () => {},
         () => {},
         () => {},
+        () => {},
+        () => {},
+        () => {},
+        () => {},
         req.body as accessRequestResponseBody,
     );
     return res.send(response);
@@ -35,6 +39,8 @@ accessRequestRouter.get('', async (req: Request, res: Response) => {
 
 accessRequestRouter.put('', async (req: Request, res: Response) => {
     const response = await controller.updateAccessRequest(
+        () => {},
+        () => {},
         () => {},
         () => {},
         () => {},

--- a/src/tests/routes/accessRequest.spec.ts
+++ b/src/tests/routes/accessRequest.spec.ts
@@ -6,7 +6,10 @@ import { GCNotifyEmailSuccessResponse } from '../commonResponses';
 import { AccessRequestController } from '../../controllers/AccessRequestController';
 import { TsoaResponse } from 'tsoa';
 import {
+    DuplicateRequestErrorType,
     GenericTypeORMErrorType,
+    InvalidTokenErrorResponse,
+    UnauthorizedErrorResponse,
     requiredFieldErrorType,
     serverErrorType,
 } from '../../helpers/types';
@@ -35,11 +38,12 @@ describe('Access Request endpoints', () => {
             'sendSms',
         ).mockResolvedValueOnce(GCNotifyEmailSuccessResponse);
 
-        jest.spyOn(AccessRequest, 'createRequest').mockResolvedValue({
+        jest.spyOn(AccessRequest, 'createRequest').mockResolvedValueOnce({
             createdRequest: {
                 identifiers: '123',
             },
         });
+        jest.spyOn(AccessRequest, 'getRequestList').mockResolvedValueOnce([]);
 
         const reqBody = {
             userGuid: '82dc08e5-cbca-40c2-9d35-a4d1407d5f8d',
@@ -53,10 +57,17 @@ describe('Access Request endpoints', () => {
             requestReason: 'To get access to site',
         };
         const res:
+            | TsoaResponse<400, InvalidTokenErrorResponse>
+            | TsoaResponse<401, UnauthorizedErrorResponse>
+            | TsoaResponse<409, DuplicateRequestErrorType>
             | TsoaResponse<422, GenericTypeORMErrorType>
             | TsoaResponse<422, requiredFieldErrorType>
             | TsoaResponse<500, serverErrorType>
             | undefined = await (proto as any).createAccessRequest(
+            () => {},
+            () => {},
+            () => {},
+            () => {},
             () => {},
             () => {},
             () => {},


### PR DESCRIPTION
This PR changes the post method of /access-request to no longer accept duplicate "NotGranted" requests. It returns a 409 error in these cases.