### PR TITLE
BVPS-348: Audit History Table missing information

### DIFF
--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -223,6 +223,7 @@ const models: TsoaRoute.Models = {
             "sentToPhone": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
             "pinCreatedAt": {"dataType":"string","required":true},
             "updatedAt": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "alteredByName": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
             "alteredByUsername": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
             "livePinId": {"dataType":"string","required":true},
             "action": {"ref":"pinAuditAction","required":true},

--- a/src/build/swagger.json
+++ b/src/build/swagger.json
@@ -483,6 +483,10 @@
 						"type": "string",
 						"nullable": true
 					},
+					"alteredByName": {
+						"type": "string",
+						"nullable": true
+					},
 					"alteredByUsername": {
 						"type": "string",
 						"nullable": true
@@ -506,6 +510,7 @@
 					"sentToPhone",
 					"pinCreatedAt",
 					"updatedAt",
+					"alteredByName",
 					"alteredByUsername",
 					"livePinId",
 					"action",
@@ -521,6 +526,7 @@
 					"sentToPhone": "19021234567",
 					"pinCreatedAt": "2023-08-24T15:01:49.628Z",
 					"updatedAt": "2023-08-24T15:06:27.269Z",
+					"alteredByName": "Self",
 					"alteredByUsername": "self",
 					"livePinId": "31be8df8-3284-4b05-bb2b-f11b7e77cba0",
 					"action": "C",

--- a/src/controllers/PinAuditLogController.ts
+++ b/src/controllers/PinAuditLogController.ts
@@ -70,6 +70,7 @@ export class PinAuditLogController extends Controller {
                 sentToPhone: true,
                 logCreatedAt: true,
                 pinCreatedAt: true,
+                alteredByName: true,
                 alteredByUsername: true,
                 livePinId: true,
             };

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -405,6 +405,7 @@ export interface auditLogReturn {
     "sentToPhone": "19021234567",
     "pinCreatedAt": "2023-08-24T15:01:49.628Z",
     "updatedAt": "2023-08-24T15:06:27.269Z",
+	"alteredByName": "Self",
     "alteredByUsername": "self",
 	"livePinId": "31be8df8-3284-4b05-bb2b-f11b7e77cba0",
     "action": "C",
@@ -420,6 +421,7 @@ export interface auditLogInfo {
     sentToPhone: string | null;
     pinCreatedAt: string;
     updatedAt: string | null;
+    alteredByName: string | null;
     alteredByUsername: string | null;
     livePinId: string;
     action: pinAuditAction;


### PR DESCRIPTION
This pr adds "alteredByName" to the list of returned fields for the /audit-trails api. Note that this will require a FE fix for it to show up in the UI, where the username should be the "alteredByUsername" field, and the type is "expirationReason" (Note that we should probably give this a diffferent name, as it can be null if it hasn't been expired...)