### PR TITLE
BVPS-420: Add livePinId to verify pin API

### DIFF
--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -51,6 +51,7 @@ const models: TsoaRoute.Models = {
         "dataType": "refObject",
         "properties": {
             "verified": {"dataType":"boolean","required":true},
+            "livePinId": {"dataType":"string"},
             "reason": {"ref":"verifyPinErrorType"},
         },
         "additionalProperties": false,

--- a/src/build/swagger.json
+++ b/src/build/swagger.json
@@ -59,6 +59,9 @@
 					"verified": {
 						"type": "boolean"
 					},
+					"livePinId": {
+						"type": "string"
+					},
 					"reason": {
 						"$ref": "#/components/schemas/verifyPinErrorType"
 					}

--- a/src/controllers/pinController.ts
+++ b/src/controllers/pinController.ts
@@ -1490,9 +1490,10 @@ export class PINController extends Controller {
         @Res() serverErrorResponse: TsoaResponse<500, verifyPinResponse>,
         @Body() requestBody: verifyPinRequestBody,
     ): Promise<verifyPinResponse> {
+        let matchId = '';
         try {
             const response = await findPin(
-                { pin: true, pids: true },
+                { pin: true, pids: true, livePinId: true },
                 { pin: requestBody.pin },
             );
             if (response.length < 1) {
@@ -1507,6 +1508,7 @@ export class PINController extends Controller {
                         for (const dbPid of sortedPids) {
                             if (resultPid === dbPid) {
                                 isMatch = true;
+                                matchId = result.livePinId;
                                 break outerLoop; // we have a match, can stop checking
                             }
                         }
@@ -1546,6 +1548,6 @@ export class PINController extends Controller {
                 });
             }
         }
-        return { verified: true };
+        return { verified: true, livePinId: matchId };
     }
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -657,6 +657,7 @@ export interface verifyPinRequestBody {
  */
 export interface verifyPinResponse {
     verified: boolean;
+    livePinId?: string;
     reason?: verifyPinErrorType;
 }
 

--- a/src/tests/routes/pins.spec.ts
+++ b/src/tests/routes/pins.spec.ts
@@ -1216,6 +1216,7 @@ describe('Pin endpoints', () => {
             .set({ 'x-api-key': key });
         expect(res.statusCode).toBe(200);
         expect(res.body.verified).toBeTruthy;
+        expect(res.body.livePinId).toEqual(ActivePINMultiResponse[0].livePinId);
     });
 
     test('verify PIN on API key not matching returns 400', async () => {


### PR DESCRIPTION
This PR adds the livePinId to successful verifications on the /pins/verify endpoint.

- Added livePinId to true verify pin responses and updated tests