### PR TITLE
BVPS-444: Add /pins/etl-expire endpoint

### DIFF
--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -891,6 +891,38 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        app.post('/pins/etl-expire',
+            authenticateMiddleware([{"vhers_api_key":[]}]),
+            ...(fetchMiddlewares<RequestHandler>(PINController)),
+            ...(fetchMiddlewares<RequestHandler>(PINController.prototype.expirePinEtl)),
+
+            function PINController_expirePinEtl(request: any, response: any, next: any) {
+            const args = {
+                    _invalidTokenErrorResponse: {"in":"res","name":"400","required":true,"ref":"InvalidTokenErrorResponse"},
+                    _unauthorizedErrorResponse: {"in":"res","name":"401","required":true,"ref":"UnauthorizedErrorResponse"},
+                    entityErrorResponse: {"in":"res","name":"422","required":true,"ref":"EntityNotFoundErrorType"},
+                    typeORMErrorResponse: {"in":"res","name":"422","required":true,"ref":"GenericTypeORMErrorType"},
+                    requiredFieldErrorResponse: {"in":"res","name":"422","required":true,"ref":"requiredFieldErrorType"},
+                    serverErrorResponse: {"in":"res","name":"500","required":true,"ref":"serverErrorType"},
+                    requestBody: {"in":"body","name":"requestBody","required":true,"ref":"expireRequestBody"},
+            };
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = getValidatedArgs(args, request, response);
+
+                const controller = new PINController();
+
+
+              const promise = controller.expirePinEtl.apply(controller, validatedArgs as any);
+              promiseHandler(controller, promise, response, undefined, next);
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         app.post('/pins/verify',
             authenticateMiddleware([{"vhers_api_key":[]}]),
             ...(fetchMiddlewares<RequestHandler>(PINController)),

--- a/src/build/swagger.json
+++ b/src/build/swagger.json
@@ -2176,6 +2176,82 @@
 				}
 			}
 		},
+		"/pins/etl-expire": {
+			"post": {
+				"operationId": "ExpirePinEtl",
+				"responses": {
+					"200": {
+						"description": "The deleted pin",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ActivePin"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InvalidTokenErrorResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UnauthorizedErrorResponse"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/requiredFieldErrorType"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/serverErrorType"
+								}
+							}
+						}
+					}
+				},
+				"description": "Used for expiring pins by their id (livePinId) from the etl job. Requires a reason for expiration, and if not a change of ownership, the name and username of who is expiring the pin.\nExpected error codes and messages:\n- `422`\n\t-- `Could not find any entity of type \"ActivePin\" matching: {\\n    \"livePinId\": \"id here\"\\n}`\n\t-- `Must provide an expiration name when expiring a PIN`\n\t-- `Must provide an expiration username when expiring a PIN`\n- `500`\n\t-- `Internal Server Error`",
+				"security": [
+					{
+						"vhers_api_key": []
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"description": "The body of the request. Note that expiredByUsername is only required for reasons other than \"CO\" (change of ownership).",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/expireRequestBody",
+								"description": "The body of the request. Note that expiredByUsername is only required for reasons other than \"CO\" (change of ownership)."
+							}
+						}
+					}
+				}
+			}
+		},
 		"/pins/verify": {
 			"post": {
 				"operationId": "VerifyPin",

--- a/src/helpers/RequiredFieldError.ts
+++ b/src/helpers/RequiredFieldError.ts
@@ -1,0 +1,1 @@
+export class RequiredFieldError extends Error {}

--- a/src/routes/pins.ts
+++ b/src/routes/pins.ts
@@ -83,6 +83,19 @@ pinsRouter.post('/expire', async (req: Request, res: Response) => {
     return res.send(response);
 });
 
+pinsRouter.post('/etl-expire', async (req: Request, res: Response) => {
+    const response = await controller.expirePinEtl(
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        req.body,
+    );
+    return res.send(response);
+});
+
 pinsRouter.post('/verify', async (req: Request, res: Response) => {
     const response = await controller.verifyPin(
         () => {},

--- a/src/tests/routes/pins.spec.ts
+++ b/src/tests/routes/pins.spec.ts
@@ -1494,6 +1494,114 @@ describe('Pin endpoints', () => {
         expect(res.body.message).toBe('An unknown error occured');
     });
 
+    /* 
+		/etl-expire endpoint tests 
+	*/
+    test('etl-expire PIN should return expired PIN', async () => {
+        jest.spyOn(
+            PINController.prototype as any,
+            'pinRequestBodyValidate',
+        ).mockResolvedValueOnce([]);
+
+        jest.spyOn(ActivePIN as any, 'deletePin').mockResolvedValueOnce(
+            DeletePINSuccessResponse,
+        );
+
+        const res = await request(app)
+            .post('/pins/etl-expire')
+            .send({
+                livePinId: 'ca609097-7b4f-49a7-b2e9-efb78afb3ae6',
+                expirationReason: expirationReason.ChangeOfOwnership,
+                propertyAddress: '123 example st',
+                email: 'test@gmail.com',
+            })
+            .set({ 'x-api-key': key });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.livePinId).toBe('ca609097-7b4f-49a7-b2e9-efb78afb3ae6');
+    });
+
+    test('etl-expire PIN should fail without username for non-system expirations', async () => {
+        const res = await request(app)
+            .post('/pins/etl-expire')
+            .send({
+                livePinId: 'ca609097-7b4f-49a7-b2e9-efb78afb3ae6',
+                expirationReason: expirationReason.CallCenterPinReset,
+                propertyAddress: '123 example st',
+                email: 'test@gmail.com',
+            })
+            .set({ 'x-api-key': key });
+        expect(res.statusCode).toBe(422);
+        expect(res.body.message).toBe(
+            'Must provide an expiration username when expiring a PIN',
+        );
+    });
+
+    test('etl-expire PIN without existing PIN returns 422', async () => {
+        jest.clearAllMocks();
+        jest.spyOn(ActivePIN, 'deletePin').mockImplementationOnce(async () => {
+            throw new EntityNotFoundError(ActivePin, {
+                livePinId: 'ca609097-7b4f-49a7-b2e9-efb78afb3ae7',
+                propertyAddress: '123 example st',
+                email: 'test@gmail.com',
+            });
+        });
+        const res = await request(app)
+            .post('/pins/etl-expire')
+            .send({
+                livePinId: 'ca609097-7b4f-49a7-b2e9-efb78afb3ae7',
+                expirationReason: expirationReason.CallCenterPinReset,
+                expiredByUsername: 'Test',
+                propertyAddress: '123 example st',
+                email: 'test@gmail.com',
+            })
+            .set({ 'x-api-key': key });
+        expect(res.statusCode).toBe(422);
+        expect(res.body.message).toBe(
+            `Could not find any entity of type "ActivePin" matching: {\n    "livePinId": "ca609097-7b4f-49a7-b2e9-efb78afb3ae7",\n    "propertyAddress": "123 example st",\n    "email": "test@gmail.com"\n}`,
+        );
+    });
+
+    test('etl-expire PIN on generic TypeORM Error returns 422', async () => {
+        jest.spyOn(ActivePIN, 'deletePin').mockImplementationOnce(async () => {
+            throw new TypeORMError(
+                'Could not remove ActivePin matching: {\n    livePinId: "ca609097-7b4f-49a7-b2e9-efb78afb3ae7"\n}',
+            );
+        });
+        const res = await request(app)
+            .post('/pins/etl-expire')
+            .send({
+                livePinId: 'ca609097-7b4f-49a7-b2e9-efb78afb3ae7',
+                expirationReason: expirationReason.CallCenterPinReset,
+                expiredByUsername: 'Test',
+                propertyAddress: '123 example st',
+                email: 'test@gmail.com',
+            })
+            .set({ 'x-api-key': key });
+        expect(res.statusCode).toBe(422);
+        expect(res.body.message).toBe(
+            'Could not remove ActivePin matching: {\n    livePinId: "ca609097-7b4f-49a7-b2e9-efb78afb3ae7"\n}',
+        );
+    });
+
+    test('etl-expire PIN on generic error returns 500', async () => {
+        jest.spyOn(ActivePIN, 'deletePin').mockImplementationOnce(async () => {
+            throw new Error('An unknown error occured');
+        });
+        const res = await request(app)
+            .post('/pins/etl-expire')
+            .send({
+                livePinId: 'ca609097-7b4f-49a7-b2e9-efb78afb3ae7',
+                expirationReason: expirationReason.CallCenterPinReset,
+                expiredByUsername: 'Test',
+                propertyAddress: '123 example st',
+                email: 'test@gmail.com',
+            })
+            .set({ 'x-api-key': key });
+        expect(res.statusCode).toBe(500);
+        expect(res.body.message).toBe('An unknown error occured');
+    });
+
     /*
 		/verify endpoint tests
 	*/


### PR DESCRIPTION
This PR adds the /pins/etl-expire endpoint, which uses api key auth rather than keycloak for the etl job.

- Added /pins/etl-expire endpoint with api key auth and tests