### PR TITLE
BVPS-457: Fixing /pins/etl-expire to not require property address, email or phone

### DIFF
--- a/src/build/routes.ts
+++ b/src/build/routes.ts
@@ -363,7 +363,7 @@ const models: TsoaRoute.Models = {
             "livePinId": {"dataType":"string","required":true},
             "expirationReason": {"ref":"expirationReason","required":true},
             "expiredByUsername": {"dataType":"string"},
-            "propertyAddress": {"dataType":"string","required":true},
+            "propertyAddress": {"dataType":"string"},
             "phoneNumber": {"dataType":"string"},
             "email": {"dataType":"string"},
         },

--- a/src/build/swagger.json
+++ b/src/build/swagger.json
@@ -926,7 +926,7 @@
 				"additionalProperties": false
 			},
 			"expireRequestBody": {
-				"description": "The request body for a pin expiration request.\nNote that expiredByUsername is only required for reasons other\nthan \"CO\" (change of ownership).",
+				"description": "The request body for a pin expiration request.\nNote that expiredByUsername, propertyAddress, email and phone\nnumber are only required for reasons other\nthan \"CO\" (change of ownership).",
 				"properties": {
 					"livePinId": {
 						"type": "string"
@@ -949,8 +949,7 @@
 				},
 				"required": [
 					"livePinId",
-					"expirationReason",
-					"propertyAddress"
+					"expirationReason"
 				],
 				"type": "object",
 				"additionalProperties": false,

--- a/src/controllers/pinController.ts
+++ b/src/controllers/pinController.ts
@@ -1366,6 +1366,27 @@ export class PINController extends Controller {
             logger.warn(message);
             throw new RequiredFieldError(message);
         }
+        if (
+            requestBody.expirationReason !==
+                expirationReason.ChangeOfOwnership &&
+            !requestBody.phoneNumber &&
+            !requestBody.email
+        ) {
+            const message =
+                'An email and/or phone number must be provided for non-system PIN expiration';
+            logger.warn(message);
+            throw new RequiredFieldError(message);
+        }
+        if (
+            requestBody.expirationReason !==
+                expirationReason.ChangeOfOwnership &&
+            !requestBody.propertyAddress
+        ) {
+            const message =
+                'Property address must be provided for non-system PIN expiration';
+            logger.warn(message);
+            throw new RequiredFieldError(message);
+        }
         let deletedPin: ActivePin | undefined;
 
         try {

--- a/src/db/AccessRequest.db.ts
+++ b/src/db/AccessRequest.db.ts
@@ -1,4 +1,3 @@
-// import { Query } from 'tsoa';
 import { InsertResult, FindOptionsOrderValue, UpdateResult } from 'typeorm';
 import { AppDataSource } from '../data-source';
 import { AccessRequest } from '../entity/AccessRequest';
@@ -38,10 +37,8 @@ export async function createRequest(
                     AccessRequest,
                     newRequest,
                 );
-
                 const notificationResponse =
                     await sendAccessRequestNotifications(accessRequestInfo);
-
                 if (notificationResponse) {
                     return { createdRequest };
                 } else {
@@ -120,13 +117,11 @@ export async function updateRequestStatus(
                         'Request to update not found in database',
                     );
                 }
-
                 const notificationResponse =
                     await sendAccessApproveAndRejectNotifications(
                         requestBody,
                         templateId,
                     );
-
                 if (notificationResponse) {
                     return { updatedRequest };
                 } else {

--- a/src/db/Users.db.ts
+++ b/src/db/Users.db.ts
@@ -83,11 +83,6 @@ export async function getUserList(where?: object): Promise<Users[] | any> {
 }
 /**
  * update user object with updated field value
- *
- * @export
- * @param {object} userId
- * @param {object} updateFields
- * @return {*}  affected row
  */
 export async function updateUser(
     userId: object,
@@ -95,6 +90,7 @@ export async function updateUser(
     requestBody: userUpdateRequestBody,
 ): Promise<any | undefined> {
     let transactionReturn;
+    const templateId = process.env.GC_NOTIFY_UPDATE_USER_EMAIL_TEMPLATE_ID!;
     try {
         transactionReturn = (await AppDataSource.transaction(
             async (manager) => {
@@ -103,10 +99,6 @@ export async function updateUser(
                     userId,
                     updateFields,
                 );
-
-                const templateId =
-                    process.env.GC_NOTIFY_UPDATE_USER_EMAIL_TEMPLATE_ID!;
-
                 // Call GC Notify only if role is updated
                 if ('role' in updateFields) {
                     const notificationResponse =
@@ -114,7 +106,6 @@ export async function updateUser(
                             requestBody,
                             templateId,
                         );
-
                     if (notificationResponse) {
                         return { updatedRequest };
                     } else {
@@ -166,6 +157,8 @@ export async function deactivateUsers(
     }
 
     let transactionReturn;
+    const templateId =
+        process.env.GC_NOTIFY_USER_DEACTIVATION_EMAIL_TEMPLATE_ID!;
 
     try {
         transactionReturn = (await AppDataSource.transaction(
@@ -180,16 +173,11 @@ export async function deactivateUsers(
                         'User(s) to deactivate not found in database',
                     );
                 }
-
-                const templateId =
-                    process.env.GC_NOTIFY_USER_DEACTIVATION_EMAIL_TEMPLATE_ID!;
-
                 const notificationResponse =
                     await sendDeactiveUserNotifications(
                         requestBody,
                         templateId,
                     );
-
                 if (notificationResponse) {
                     return { updatedUser };
                 } else {

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -279,7 +279,8 @@ export enum roleType {
 
 /**
  * The request body for a pin expiration request.
- * Note that expiredByUsername is only required for reasons other
+ * Note that expiredByUsername, propertyAddress, email and phone
+ * number are only required for reasons other
  * than "CO" (change of ownership).
  * @example {
  	"livePinId": "ca609097-7b4f-49a7-b2e9-efb78afb3ae6",
@@ -293,11 +294,10 @@ export interface expireRequestBody {
     livePinId: string;
     expirationReason: expirationReason;
     expiredByUsername?: string;
-    propertyAddress: string;
+    propertyAddress?: string;
     phoneNumber?: string;
     email?: string;
 }
-// TODO: Change to look up by GUID??
 
 /**
  * The request body for a pin creation / recreation request.

--- a/src/tests/db/AccessRequest.db.spec.ts
+++ b/src/tests/db/AccessRequest.db.spec.ts
@@ -1,6 +1,13 @@
-import { DataSource, EntityMetadata, InsertResult } from 'typeorm';
+import { DataSource, EntityMetadata, InsertResult, Repository } from 'typeorm';
 import * as AccessRequest from '../../db/AccessRequest.db';
-import { AccessRequestBody } from '../commonResponses';
+import {
+    AccessRequestBody,
+    AccessRequestUpdateRequestBody,
+    UserRequestPendingResponse,
+    ValidUpdateAccessRequestBody,
+} from '../commonResponses';
+import { UpdateResult } from 'typeorm/browser';
+import { NotFoundError } from '../../helpers/NotFoundError';
 
 // mock out db
 jest.mock('typeorm', () => {
@@ -55,5 +62,95 @@ describe('Access Request DB tests', () => {
 
         const res = await AccessRequest.createRequest(AccessRequestBody);
         expect(res).toBe(undefined);
+    });
+
+    test('updateRequestStatus successfully updates a request', async () => {
+        /*
+         * Unfortunately, because the other typeORM calls are wrapped in a transaction, I have to
+         * mock the whole thing and not the individual db calls within it.
+         */
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedRequest: { affected: 1 } as UpdateResult,
+        });
+        const res = await AccessRequest.updateRequestStatus(
+            AccessRequestUpdateRequestBody,
+            'abcdef',
+        );
+        expect(res).toBe(1);
+    });
+
+    test(`updateRequestStatus doesn't update a request when a NotFoundError is thrown`, async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockImplementationOnce(
+            () => {
+                throw new NotFoundError('Oops!');
+            },
+        );
+        await expect(
+            AccessRequest.updateRequestStatus(
+                ValidUpdateAccessRequestBody,
+                'abcdef',
+            ),
+        ).rejects.toThrow(`Oops!`);
+    });
+
+    test(`updateRequestStatus doesn't update a request when an error is thrown`, async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockImplementationOnce(
+            () => {
+                throw new Error('Oops!');
+            },
+        );
+        await expect(
+            AccessRequest.updateRequestStatus(
+                AccessRequestUpdateRequestBody,
+                'abcdef',
+            ),
+        ).rejects.toThrow(
+            `An error occured while calling updateRequestStatus: Oops!`,
+        );
+    });
+
+    test(`updateRequestStatus doesn't update a request when updatedRequest affected is 0`, async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedRequest: { affected: 0 } as UpdateResult,
+        });
+        const res = await AccessRequest.updateRequestStatus(
+            AccessRequestUpdateRequestBody,
+            'abcdef',
+        );
+        expect(res).toBe(undefined);
+    });
+
+    test(`updateRequestStatus doesn't update a request when updatedRequest is undefined`, async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedRequest: undefined as unknown as UpdateResult,
+        });
+        const res = await AccessRequest.updateRequestStatus(
+            AccessRequestUpdateRequestBody,
+            'abcdef',
+        );
+        expect(res).toBe(undefined);
+    });
+
+    test('getRequestList successfully returns a list of requests', async () => {
+        jest.spyOn(Repository.prototype, 'find').mockImplementationOnce(
+            async () => {
+                return Promise.resolve(UserRequestPendingResponse);
+            },
+        );
+        const res = await AccessRequest.getRequestList();
+        expect(res.length).toBe(UserRequestPendingResponse.length);
+    });
+
+    test('getRequestList successfully returns a list of requests with where clause', async () => {
+        jest.spyOn(Repository.prototype, 'find').mockImplementationOnce(
+            async () => {
+                return Promise.resolve(UserRequestPendingResponse);
+            },
+        );
+        const res = await AccessRequest.getRequestList({
+            requestStatus: 'NotGranted',
+        });
+        expect(res.length).toBe(UserRequestPendingResponse.length);
+        expect(res[0].requestStatus).toBe('NotGranted');
     });
 });

--- a/src/tests/db/ActivePIN.db.spec.ts
+++ b/src/tests/db/ActivePIN.db.spec.ts
@@ -192,6 +192,8 @@ describe('Active PIN db tests', () => {
             pins,
             emailPhone,
             propertyAddress,
+            'Username',
+            'Name',
         );
         expect(response[0].length).toBe(1);
         expect(response[0][0]).toBe(
@@ -231,6 +233,6 @@ describe('Active PIN db tests', () => {
                 [],
                 ['USER_ACCESS', 'PROPERTY_SEARCH', 'ACCESS_REQUEST'],
             ),
-        ).rejects.toThrowError(`No pids available for search`);
+        ).rejects.toThrow(`No pids available for search`);
     });
 });

--- a/src/tests/db/Users.db.spec.ts
+++ b/src/tests/db/Users.db.spec.ts
@@ -1,9 +1,13 @@
-import { DataSource, EntityMetadata, Repository } from 'typeorm';
+import { DataSource, EntityMetadata, Repository, UpdateResult } from 'typeorm';
 import * as Users from '../../db/Users.db';
 import {
     AdminPermissionResponse,
+    UserDeactivateRequestBody,
+    UserListSuccess,
+    UserUpdateRequestBody,
     UsersMultiResponse,
 } from '../commonResponses';
+import { NotFoundError } from '../../helpers/NotFoundError';
 
 // mock out db
 jest.mock('typeorm', () => {
@@ -51,5 +55,134 @@ describe('Users DB tests', () => {
         );
         const res = await Users.findPermissionByRole('Admin');
         expect(res.length).toBe(3);
+    });
+
+    test('getUserList empty where', async () => {
+        jest.spyOn(Repository.prototype, 'find').mockImplementationOnce(
+            async () => {
+                return UserListSuccess;
+            },
+        );
+        const res = await Users.getUserList();
+        expect(res.length).toBe(UserListSuccess.length);
+    });
+
+    test('getUserList with where', async () => {
+        jest.spyOn(Repository.prototype, 'find').mockImplementationOnce(
+            async () => {
+                return UserListSuccess;
+            },
+        );
+        const res = await Users.getUserList({ isActive: true });
+        expect(res.length).toBe(UserListSuccess.length);
+        expect(res[0].isActive).toBe(true);
+    });
+
+    test('updateUser returns affected', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedRequest: { affected: 1 } as UpdateResult,
+        });
+        const res = await Users.updateUser(
+            { userId: 'abcdefg' },
+            { isActive: true },
+            UserUpdateRequestBody,
+        );
+        expect(res).toBe(1);
+    });
+
+    test('updateUser returns undefined if nothing is affected', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedRequest: { affected: 0 } as UpdateResult,
+        });
+        const res = await Users.updateUser(
+            { userId: 'abcdefg' },
+            { isActive: true },
+            UserUpdateRequestBody,
+        );
+        expect(res).toBe(undefined);
+    });
+
+    test('updateUser returns undefined if update result is undefined', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedRequest: undefined as unknown as UpdateResult,
+        });
+        const res = await Users.updateUser(
+            { userId: 'abcdefg' },
+            { isActive: true },
+            UserUpdateRequestBody,
+        );
+        expect(res).toBe(undefined);
+    });
+
+    test('updateUser throws error if an error occured', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockImplementationOnce(
+            async () => {
+                throw new Error('Oops!');
+            },
+        );
+        await expect(
+            Users.updateUser(
+                { userId: 'abcdefg' },
+                { isActive: true },
+                UserUpdateRequestBody,
+            ),
+        ).rejects.toThrow(`An error occured while calling updateUser: Oops!`);
+    });
+
+    test('deactivateUsers returns affected', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedUser: { affected: 1 } as UpdateResult,
+        });
+        const res = await Users.deactivateUsers(
+            UserDeactivateRequestBody,
+            'abcdefg',
+        );
+        expect(res).toBe(1);
+    });
+
+    test('deactivateUsers returns undefined if nothing is affected', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedUser: { affected: 0 } as UpdateResult,
+        });
+        const res = await Users.deactivateUsers(
+            UserDeactivateRequestBody,
+            'abcdefg',
+        );
+        expect(res).toBe(undefined);
+    });
+
+    test('deactivateUsers returns undefined if updatedUser is undefined', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockResolvedValueOnce({
+            updatedUser: undefined as unknown as UpdateResult,
+        });
+        const res = await Users.deactivateUsers(
+            UserDeactivateRequestBody,
+            'abcdefg',
+        );
+        expect(res).toBe(undefined);
+    });
+
+    test('deactivateUsers throws error on NotFoundError', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockImplementationOnce(
+            async () => {
+                throw new NotFoundError('Oops!');
+            },
+        );
+        await expect(
+            Users.deactivateUsers(UserDeactivateRequestBody, 'abcdefg'),
+        ).rejects.toThrow('Oops!');
+    });
+
+    test('deactivateUsers throws error on error', async () => {
+        jest.spyOn(DataSource.prototype, 'transaction').mockImplementationOnce(
+            async () => {
+                throw new Error('Oops!');
+            },
+        );
+        await expect(
+            Users.deactivateUsers(UserDeactivateRequestBody, 'abcdefg'),
+        ).rejects.toThrow(
+            `An error occured while calling deactivateUsers: Oops!`,
+        );
     });
 });

--- a/src/tests/routes/pins.spec.ts
+++ b/src/tests/routes/pins.spec.ts
@@ -1429,6 +1429,38 @@ describe('Pin endpoints', () => {
         );
     });
 
+    test('expire PIN should fail without email or phone for non-system expirations', async () => {
+        const res = await request(app)
+            .post('/pins/expire')
+            .send({
+                livePinId: 'ca609097-7b4f-49a7-b2e9-efb78afb3ae6',
+                expirationReason: expirationReason.CallCenterPinReset,
+                propertyAddress: '123 example st',
+                expiredByUsername: 'jsmith',
+            })
+            .set('Cookie', `token=${token}`);
+        expect(res.statusCode).toBe(422);
+        expect(res.body.message).toBe(
+            'An email and/or phone number must be provided for non-system PIN expiration',
+        );
+    });
+
+    test('expire PIN should fail without property address for non-system expirations', async () => {
+        const res = await request(app)
+            .post('/pins/expire')
+            .send({
+                livePinId: 'ca609097-7b4f-49a7-b2e9-efb78afb3ae6',
+                expirationReason: expirationReason.CallCenterPinReset,
+                email: '123 example st',
+                expiredByUsername: 'jsmith',
+            })
+            .set('Cookie', `token=${token}`);
+        expect(res.statusCode).toBe(422);
+        expect(res.body.message).toBe(
+            'Property address must be provided for non-system PIN expiration',
+        );
+    });
+
     test('expire PIN without existing PIN returns 422', async () => {
         jest.clearAllMocks();
         jest.spyOn(ActivePIN, 'deletePin').mockImplementationOnce(async () => {


### PR DESCRIPTION
This PR fixes /pins/etl-expire to not require property address, email or phone, and also adds test coverage.