### PR TITLE
added empty string checks to pin verification

### DIFF
--- a/src/controllers/pinController.ts
+++ b/src/controllers/pinController.ts
@@ -167,6 +167,7 @@ export class PINController extends Controller {
         if (
             pinResult.addressLine_1 === undefined ||
             pinResult.addressLine_1 === null ||
+            pinResult.addressLine_1 === '' ||
             pinResult.addressLine_1.trim().toUpperCase() ===
                 'NO ADDRESS ON FILE FOR THIS OWNER'
         ) {
@@ -176,16 +177,20 @@ export class PINController extends Controller {
         }
         if (
             pinResult.lastName_1 === undefined ||
-            pinResult.lastName_1 === null
+            pinResult.lastName_1 === null ||
+            pinResult.lastName_1 === ''
         ) {
             faults.push(
                 'No legal name or corporation name is on file for this owner: please contact service BC to create or recreate your PIN',
             );
         }
         if (
-            (pinResult.city === undefined || pinResult.city === null) &&
+            (pinResult.city === undefined ||
+                pinResult.city === null ||
+                pinResult.city === '') &&
             (pinResult.postalCode === undefined ||
-                pinResult.postalCode === null)
+                pinResult.postalCode === null ||
+                pinResult.postalCode === '')
         ) {
             faults.push(
                 'No city or postal / zip code is on file for this owner: please contact service BC to create or recreate your PIN',
@@ -213,7 +218,11 @@ export class PINController extends Controller {
             postalCodeScore = NaN;
 
         // If given name is present, it isn't a corporation. These only have lastName_1 and sometimes lastName_2
-        if (pinResult.givenName !== null && pinResult.givenName !== undefined) {
+        if (
+            pinResult.givenName !== null &&
+            pinResult.givenName !== undefined &&
+            pinResult.givenName !== ''
+        ) {
             if (
                 requestBody.givenName === null ||
                 requestBody.givenName === undefined
@@ -233,7 +242,8 @@ export class PINController extends Controller {
             // it's a corporation
             if (
                 pinResult.incorporationNumber !== null &&
-                pinResult.incorporationNumber !== undefined
+                pinResult.incorporationNumber !== undefined &&
+                pinResult.incorporationNumber !== ''
             ) {
                 if (
                     requestBody.incorporationNumber === null ||
@@ -266,7 +276,11 @@ export class PINController extends Controller {
         )
             combinedRequestLastNames += ' ' + requestBody.lastName_2.trim();
         combinedResultLastNames = pinResult.lastName_1;
-        if (pinResult.lastName_2 !== null && pinResult.lastName_2 !== undefined)
+        if (
+            pinResult.lastName_2 !== null &&
+            pinResult.lastName_2 !== undefined &&
+            pinResult.lastName_2 !== ''
+        )
             combinedResultLastNames += ' ' + pinResult.lastName_2.trim();
         lastNamesScore = this.score(
             combinedResultLastNames,
@@ -292,7 +306,8 @@ export class PINController extends Controller {
         combinedResultAddress = pinResult.addressLine_1;
         if (
             pinResult.addressLine_2 !== null &&
-            pinResult.addressLine_2 !== undefined
+            pinResult.addressLine_2 !== undefined &&
+            pinResult.addressLine_2 !== ''
         )
             combinedResultAddress += ' ' + pinResult.addressLine_2.trim();
         streetAddressScore = this.score(
@@ -303,7 +318,11 @@ export class PINController extends Controller {
         );
 
         // City
-        if (pinResult.city !== null && pinResult.city !== undefined) {
+        if (
+            pinResult.city !== null &&
+            pinResult.city !== undefined &&
+            pinResult.city !== ''
+        ) {
             if (requestBody.city === null || requestBody.city === undefined)
                 cityScore = 0;
             else {
@@ -320,7 +339,8 @@ export class PINController extends Controller {
         // Province Abbreviation
         if (
             pinResult.provinceAbbreviation !== null &&
-            pinResult.provinceAbbreviation !== undefined
+            pinResult.provinceAbbreviation !== undefined &&
+            pinResult.provinceAbbreviation !== ''
         ) {
             if (
                 requestBody.provinceAbbreviation === null ||
@@ -343,7 +363,11 @@ export class PINController extends Controller {
         }
 
         // Country
-        if (pinResult.country !== null && pinResult.country !== undefined) {
+        if (
+            pinResult.country !== null &&
+            pinResult.country !== undefined &&
+            pinResult.country !== ''
+        ) {
             if (
                 requestBody.country === null ||
                 requestBody.country === undefined
@@ -364,7 +388,8 @@ export class PINController extends Controller {
         // Postal Code
         if (
             pinResult.postalCode !== null &&
-            pinResult.postalCode !== undefined
+            pinResult.postalCode !== undefined &&
+            pinResult.postalCode !== ''
         ) {
             if (
                 requestBody.postalCode === null ||


### PR DESCRIPTION
This ensures that the pin verification scoring treats database empty strings the same as null values, as this is how the etl job stores them.