### PR TITLE
BVPS-480: Fix duplicate active user in db when new request is granted

### DIFF
--- a/src/migration/1702921951091-migration.ts
+++ b/src/migration/1702921951091-migration.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Migration1702921951091 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const schemaName = process.env.NODE_ENV === 'test' ? 'test' : 'public';
+        await queryRunner.query(`CREATE OR REPLACE FUNCTION ${schemaName}.add_new_user()
+			RETURNS trigger
+			LANGUAGE plpgsql
+			AS $function$
+			BEGIN
+				IF new.request_status = 'Granted'
+				THEN
+				UPDATE ${schemaName}.users SET is_active=FALSE, updated_by='System', deactivation_reason='New Request Approval' WHERE user_guid=NEW.user_guid AND is_active=TRUE;
+				INSERT INTO ${schemaName}.users
+				(user_guid,identity_type,role,organization,email,user_name,given_name,last_name,is_active,created_at)
+				VALUES (new.user_guid,new.identity_type,new.requested_role,new.organization,new.email,new.user_name,new.given_name,new.last_name,true,now());
+				END IF;
+				RETURN NEW;
+
+			END;
+			$function$
+			;
+		`);
+        // Add trigger for request status update
+        await queryRunner.query(
+            `DROP TRIGGER IF EXISTS update_request_status ON ${schemaName}.access_request;`,
+        );
+        await queryRunner.query(`CREATE TRIGGER update_request_status AFTER UPDATE OF request_status ON
+      ${schemaName}.access_request FOR EACH ROW EXECUTE FUNCTION ${schemaName}.add_new_user();`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const schemaName = process.env.NODE_ENV === 'test' ? 'test' : 'public';
+        await queryRunner.query(`CREATE OR REPLACE FUNCTION ${schemaName}.add_new_user()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $function$
+          BEGIN
+            IF new.request_status = 'Granted'
+            THEN
+              INSERT INTO ${schemaName}.users
+              (user_guid,identity_type,role,organization,email,user_name,given_name,last_name,is_active,created_at)
+              VALUES (new.user_guid,new.identity_type,new.requested_role,new.organization,new.email,new.user_name,new.given_name,new.last_name,true,now());
+            END IF;
+            RETURN NEW;
+
+          END;
+        $function$
+        ;`);
+        await queryRunner.query(
+            `DROP TRIGGER IF EXISTS update_request_status ON ${schemaName}.access_request;`,
+        );
+        await queryRunner.query(`CREATE TRIGGER update_request_status AFTER UPDATE OF request_status ON
+      ${schemaName}.access_request FOR EACH ROW EXECUTE FUNCTION ${schemaName}.add_new_user();`);
+    }
+}


### PR DESCRIPTION
This PR fixes having duplicate active users when approving a new request for a previously active user, which would cause users to retain their old permissions.