### PR TITLE
GC notify call fix - Access Request

### DIFF
--- a/src/helpers/GCNotifyCalls.ts
+++ b/src/helpers/GCNotifyCalls.ts
@@ -50,8 +50,8 @@ export async function sendAccessRequestNotifications(
         // Standard requests go to all admins, super-admins, vhers_admin
         else if (accessRequestInfo.requestedRole === 'Standard') {
             const result = await findUser({ email: true }, [
-                { role: 'Admin' },
-                { role: 'SuperAdmin' },
+                { role: 'Admin', isActive: true },
+                { role: 'SuperAdmin', isActive: true },
             ]);
             // removing dupilcate emails
             const map = new Map();


### PR DESCRIPTION
Checking if admin user is active before calling GC Notify with admin emails for Access Request